### PR TITLE
No longer need to kill Chrome to run

### DIFF
--- a/bin/templates/project/cordova/run
+++ b/bin/templates/project/cordova/run
@@ -23,4 +23,4 @@ var shell = require('shelljs'),
     spawn = require('child_process').spawn,
     project = 'file://' + shell.pwd() + '/platforms/browser/www/index.html';
 
-spawn('open', ['-a', 'Google\ Chrome', '--args', '--disable-web-security', project]);
+spawn('open', ['-n', '-a', 'Google\ Chrome', '--args', '--disable-web-security', '--user-data-dir=/tmp/temp_chrome_user_data_dir_for_cordova_browser', project]);


### PR DESCRIPTION
The instructions to run browser platform started with: "kill chrome".  With this patch, you will use a temporary chrome user data dir (profile), which will allow you to create a second chrome process with the appropriate flags applied.
