### PR TITLE
CB-8760 'platform list' shows wrong version for browser platform.

### DIFF
--- a/bin/templates/project/cordova/version
+++ b/bin/templates/project/cordova/version
@@ -20,6 +20,6 @@
 */
 
 // Coho updates this line:
-var VERSION = "3.5.2";
+var VERSION = "3.7.0-dev";
 
 console.log(VERSION);


### PR DESCRIPTION
Updated version file for `browser` platform (note that this relies on a change in `coho` to keep it in sync).