### PR TITLE
CB-9350 'cordova run browser' throws an exception.

### DIFF
--- a/bin/templates/project/cordova/run
+++ b/bin/templates/project/cordova/run
@@ -44,10 +44,10 @@ function start(argv) {
         configXML = fs.readFileSync(configFile, 'utf8'),
         sourceFile = /<content[\s]+?src\s*=\s*"(.*?)"/i.exec(configXML);
 
-    serve.servePlatform({platform:'browser', port:args.port}).then(function (serverInfo) {
+    serve.servePlatform('browser', {port: args.port}).then(function (serverInfo) {
         var projectUrl = url.resolve('http://localhost:' + serverInfo.port + '/', sourceFile ? sourceFile[1] : 'index.html');
         console.log('Static file server running @ ' + projectUrl + '\nCTRL + C to shut down');
-        return serve.launchBrowser(args.target, projectUrl);
+        return serve.launchBrowser({target: args.target, url: projectUrl});
     }).done();
 }
 


### PR DESCRIPTION
The `run` command in `cordova-browser` was using an old (never released) API for `cordova-serve` (I clearly checked in the wrong version of the code when adding `cordova-serve` support to `cordova-browser`).