### PR TITLE
CB-9669 Browser exec should have more failsafes

### DIFF
--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -19,30 +19,93 @@
  *
 */
 
+/*jslint sloppy:true, plusplus:true*/
+/*global require, module, console */
+
 var cordova = require('cordova');
 var execProxy = require('cordova/exec/proxy');
 
-module.exports = function(success, fail, service, action, args) {
+/**
+ * Execute a cordova command.  It is up to the native side whether this action
+ * is synchronous or asynchronous.  The native side can return:
+ *      Synchronous: PluginResult object as a JSON string
+ *      Asynchronous: Empty string ""
+ * If async, the native side will cordova.callbackSuccess or cordova.callbackError,
+ * depending upon the result of the action.
+ *
+ * @param {Function} success    The success callback
+ * @param {Function} fail       The fail callback
+ * @param {String} service      The name of the service to use
+ * @param {String} action       Action to be run in cordova
+ * @param {String[]} [args]     Zero or more arguments to pass to the method
+ */
+module.exports = function (success, fail, service, action, args) {
 
     var proxy = execProxy.get(service, action);
 
+    args = args || [];
+
     if (proxy) {
+        
         var callbackId = service + cordova.callbackId++;
-
-        if (typeof success == "function" || typeof fail == "function") {
-            cordova.callbacks[callbackId] = {success:success, fail:fail};
+        
+        if (typeof success === "function" || typeof fail === "function") {
+            cordova.callbacks[callbackId] = {success: success, fail: fail};
         }
-
         try {
-            proxy(success, fail, args);
+
+            
+
+            // callbackOptions param represents additional optional parameters command could pass back, like keepCallback or
+            // custom callbackId, for example {callbackId: id, keepCallback: true, status: cordova.callbackStatus.JSON_EXCEPTION }
+            // CB-5806 [Windows8] Add keepCallback support to proxy
+            var onSuccess = function (result, callbackOptions) {
+                callbackOptions = callbackOptions || {};
+                var callbackStatus;
+                // covering both undefined and null.
+                // strict null comparison was causing callbackStatus to be undefined
+                // and then no callback was called because of the check in cordova.callbackFromNative
+                // see CB-8996 Mobilespec app hang on windows
+                if (callbackOptions.status !== undefined && callbackOptions.status !== null) {
+                    callbackStatus = callbackOptions.status;
+                }
+                else {
+                    callbackStatus = cordova.callbackStatus.OK;
+                }
+                cordova.callbackSuccess(callbackOptions.callbackId || callbackId,
+                    {
+                        status: callbackStatus,
+                        message: result,
+                        keepCallback: callbackOptions.keepCallback || false
+                    });
+            };
+            var onError = function (err, callbackOptions) {
+                callbackOptions = callbackOptions || {};
+                var callbackStatus;
+                // covering both undefined and null.
+                // strict null comparison was causing callbackStatus to be undefined
+                // and then no callback was called because of the check in cordova.callbackFromNative
+                // note: status can be 0
+                if (callbackOptions.status !== undefined && callbackOptions.status !== null) {
+                    callbackStatus = callbackOptions.status;
+                }
+                else {
+                    callbackStatus = cordova.callbackStatus.OK;
+                }
+                cordova.callbackError(callbackOptions.callbackId || callbackId,
+                {
+                    status: callbackStatus,
+                    message: err,
+                    keepCallback: callbackOptions.keepCallback || false
+                });
+            };
+            proxy(onSuccess, onError, args);
+
+        } catch (e) {
+            console.log("Exception calling native with command :: " + service + " :: " + action  + " ::exception=" + e);
         }
-        catch(e) {
-            // TODO throw maybe?
-            var msg = "Exception calling :: " + service + " :: " + action  + " ::exception=" + e;
-            console.log(msg);
-        }
-    }
-    else {
+    } else {
+        console.log("Error: exec proxy not found for :: " + service + " :: " + action);
         fail && fail("Missing Command Error");
     }
 };

--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -105,7 +105,11 @@ module.exports = function (success, fail, service, action, args) {
             console.log("Exception calling native with command :: " + service + " :: " + action  + " ::exception=" + e);
         }
     } else {
+
         console.log("Error: exec proxy not found for :: " + service + " :: " + action);
-        fail && fail("Missing Command Error");
+        
+        if(typeof fail === "function" ) {
+            fail("Missing Command Error");
+        }
     }
 };

--- a/cordova-js-src/exec.js
+++ b/cordova-js-src/exec.js
@@ -58,7 +58,6 @@ module.exports = function (success, fail, service, action, args) {
 
             // callbackOptions param represents additional optional parameters command could pass back, like keepCallback or
             // custom callbackId, for example {callbackId: id, keepCallback: true, status: cordova.callbackStatus.JSON_EXCEPTION }
-            // CB-5806 [Windows8] Add keepCallback support to proxy
             var onSuccess = function (result, callbackOptions) {
                 callbackOptions = callbackOptions || {};
                 var callbackStatus;

--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -905,24 +905,74 @@ module.exports = function(success, fail, service, action, args) {
 
     var proxy = execProxy.get(service, action);
 
+    args = args || [];
+
     if (proxy) {
+        
         var callbackId = service + cordova.callbackId++;
-
-        if (typeof success == "function" || typeof fail == "function") {
-            cordova.callbacks[callbackId] = {success:success, fail:fail};
+        
+        if (typeof success === "function" || typeof fail === "function") {
+            cordova.callbacks[callbackId] = {success: success, fail: fail};
         }
-
         try {
-            proxy(success, fail, args);
+
+            
+
+            // callbackOptions param represents additional optional parameters command could pass back, like keepCallback or
+            // custom callbackId, for example {callbackId: id, keepCallback: true, status: cordova.callbackStatus.JSON_EXCEPTION }
+            // CB-5806 [Windows8] Add keepCallback support to proxy
+            var onSuccess = function (result, callbackOptions) {
+                callbackOptions = callbackOptions || {};
+                var callbackStatus;
+                // covering both undefined and null.
+                // strict null comparison was causing callbackStatus to be undefined
+                // and then no callback was called because of the check in cordova.callbackFromNative
+                // see CB-8996 Mobilespec app hang on windows
+                if (callbackOptions.status !== undefined && callbackOptions.status !== null) {
+                    callbackStatus = callbackOptions.status;
+                }
+                else {
+                    callbackStatus = cordova.callbackStatus.OK;
+                }
+                cordova.callbackSuccess(callbackOptions.callbackId || callbackId,
+                    {
+                        status: callbackStatus,
+                        message: result,
+                        keepCallback: callbackOptions.keepCallback || false
+                    });
+            };
+            var onError = function (err, callbackOptions) {
+                callbackOptions = callbackOptions || {};
+                var callbackStatus;
+                // covering both undefined and null.
+                // strict null comparison was causing callbackStatus to be undefined
+                // and then no callback was called because of the check in cordova.callbackFromNative
+                // note: status can be 0
+                if (callbackOptions.status !== undefined && callbackOptions.status !== null) {
+                    callbackStatus = callbackOptions.status;
+                }
+                else {
+                    callbackStatus = cordova.callbackStatus.OK;
+                }
+                cordova.callbackError(callbackOptions.callbackId || callbackId,
+                {
+                    status: callbackStatus,
+                    message: err,
+                    keepCallback: callbackOptions.keepCallback || false
+                });
+            };
+            proxy(onSuccess, onError, args);
+
+        } catch (e) {
+            console.log("Exception calling native with command :: " + service + " :: " + action  + " ::exception=" + e);
         }
-        catch(e) {
-            // TODO throw maybe?
-            var msg = "Exception calling :: " + service + " :: " + action  + " ::exception=" + e;
-            console.log(msg);
+    } else {
+
+        console.log("Error: exec proxy not found for :: " + service + " :: " + action);
+        
+        if(typeof fail === "function" ) {
+            fail("Missing Command Error");
         }
-    }
-    else {
-        fail && fail("Missing Command Error");
     }
 };
 

--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -920,7 +920,6 @@ module.exports = function(success, fail, service, action, args) {
 
             // callbackOptions param represents additional optional parameters command could pass back, like keepCallback or
             // custom callbackId, for example {callbackId: id, keepCallback: true, status: cordova.callbackStatus.JSON_EXCEPTION }
-            // CB-5806 [Windows8] Add keepCallback support to proxy
             var onSuccess = function (result, callbackOptions) {
                 callbackOptions = callbackOptions || {};
                 var callbackStatus;


### PR DESCRIPTION
This makes the browser exec methods consistent with other js-only platforms.
CallbackID's are used, callbacks can be 'kept' and missing proxies are logged.