### PR TITLE
CB-12617 : removed node 0.x support and added engineStrict...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 sudo: false
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "6"
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,8 +22,6 @@
 
 environment:
   matrix:
-  - nodejs_version: "0.10"
-  - nodejs_version: "0.12"
   - nodejs_version: "4"
   - nodejs_version: "6"
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
         "jshint": "^2.6.0",
         "tmp": "^0.0.26"
     },
+    "engines": {
+        "node": ">=4.0.0"
+    },
+    "engineStrict": true,
     "bundledDependencies": [
         "adm-zip",
         "cordova-serve",


### PR DESCRIPTION
for users with older node versions

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?


### What testing has been done on this change?
Removed node 0.x support and added engineStrict.

### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
