### PR TITLE
CB-12847: added `bugs` entry to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
         "type": "git",
         "url": "https://git-wip-us.apache.org/repos/asf/cordova-browser.git"
     },
+    "bugs": {
+        "url": "https://issues.apache.org/jira/browse/CB"
+    },
     "keywords": [
         "cordova",
         "browser",


### PR DESCRIPTION
### What does this PR do?

Adds a bugs entry to the package.json.

### What testing has been done on this change?

None.

### Checklist
- [X] Issue reported: [CB-12847](https://issues.apache.org/jira/browse/CB-12847)
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.