### PR TITLE
CB-12804 : manifest.json added to browser during create

### DIFF
--- a/bin/template/cordova/Api.js
+++ b/bin/template/cordova/Api.js
@@ -96,6 +96,42 @@ Api.createPlatform = function (dest, config, options, events) {
         events.emit('error','createPlatform is not callable from the browser project API.');
         throw(e);
     }
+    
+    // Create manifest.json
+    var manifestJson;
+    var manifestJsonPath = path.join(dest,'manifest.json');
+
+    // Check if path exists and require manifestJsonPath.
+    if(fs.existsSync(manifestJsonPath)) {
+        try {
+            manifestJson = require(manifestJsonPath);
+        } 
+        catch (e) {
+            console.log("error : " + e);
+            events.emit('error', 'unable to require manifest.json path.');
+        }
+    } else if (manifestJson === undefined) {
+        manifestJson = {};
+        if(config){
+            if(config.name()) {
+                manifestJson.name = config.name();
+            }
+            if(config.shortName()) {
+                manifestJson.short_name = config.shortName();
+            }
+            if(config.packageName()) {
+                manifestJson.version = config.packageName();
+            }
+            if(config.description()) {
+                manifestJson.description = config.description();
+            }
+            if(config.author()) {
+                manifestJson.author = config.author();
+            }
+        }
+    }
+    fs.writeFileSync(manifestJsonPath, JSON.stringify(manifestJson, null, 4), 'utf8');
+
     return result;
 };
 


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### What does this PR do?
manifest.json added to browser during create

### What testing has been done on this change?


### Checklist
- [X] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.