### PR TITLE
CB-12905: (linux) Fix issue with freezing after launching the browser

### DIFF
--- a/node_modules/cordova-serve/src/exec.js
+++ b/node_modules/cordova-serve/src/exec.js
@@ -29,7 +29,15 @@ var child_process = require('child_process'),
 module.exports = function (cmd, opt_cwd) {
     var d = Q.defer();
     try {
+        // In Linux, the callback is not called until the process terminates.
+        // If the error is not caused within 2 seconds, then the promise will be resolved.
+        var timer = setTimeout(() => {
+            if (process.platform == 'linux') {
+                d.resolve('timeout');
+            }
+        }, 2000);
         child_process.exec(cmd, {cwd: opt_cwd, maxBuffer: 1024000}, function (err, stdout, stderr) {
+            clearTimeout(timer);
             if (err) {
                 d.reject(new Error('Error executing "' + cmd + '": ' + stderr));
             }


### PR DESCRIPTION
In Linux, the callback is not called until the process terminates.
If the error is not caused within 2 seconds, then the promise will be resolved.

### Platforms affected
- Linux

### What does this PR do?
- If the [error after launching the browser](https://github.com/Microsoft/cordova-simulate/issues/245) is not caused within 2 seconds, then the promise will be resolved. 

### What testing has been done on this change?
- manual testing launching browsers in Linux, Windows and MacOs

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
