### PR TITLE
CB-11711 clean should destroy platforms/browser/www folder contents

### DIFF
--- a/bin/template/cordova/lib/clean.js
+++ b/bin/template/cordova/lib/clean.js
@@ -23,7 +23,7 @@ var fs = require('fs'),
     shell = require('shelljs'),
     path = require('path'),
     check_reqs = require('./check_reqs'),
-    platformBuildDir = path.join('platforms', 'browser', 'build');
+    platformBuildDir = path.join('platforms', 'browser', 'www');
 
 var run = function(){
 


### PR DESCRIPTION


### Platforms affected
browser

### What does this PR do?
removes www/ folder during clean

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.
