### PR TITLE
CB-13188: fixed issues with run and build scripts

### DIFF
--- a/bin/template/cordova/lib/build.js
+++ b/bin/template/cordova/lib/build.js
@@ -22,7 +22,6 @@
 var fs = require('fs');
 var path = require('path');
 var shell = require('shelljs');
-var clean = require('./clean');
 var check_reqs = require('./check_reqs');
 
 /**
@@ -32,9 +31,7 @@ var check_reqs = require('./check_reqs');
 module.exports.run = function () {
 
     var resultP = check_reqs.run();
-    resultP.then(function () {
-        return clean.run();
-    });
+
     resultP.then(function () {
         var wwwPath = path.join(__dirname, '../../www');
 

--- a/bin/template/cordova/lib/run.js
+++ b/bin/template/cordova/lib/run.js
@@ -27,7 +27,7 @@ var cordovaServe = require('cordova-serve');
 module.exports.run = function (args) {
     // defaults
     args.port = args.port || 8000;
-    args.target = args.target || 'chrome'; // make default the system browser
+    args.target = args.target || 'default'; // make default the system browser
 
     var wwwPath = path.join(__dirname, '../../www');
     var manifestFilePath = path.resolve(path.join(wwwPath, 'manifest.json'));
@@ -54,7 +54,7 @@ module.exports.run = function (args) {
             var projectUrl = url.resolve('http://localhost:' + server.port + '/', startPage);
             console.log('startPage = ' + startPage);
             console.log('Static file server running @ ' + projectUrl + '\nCTRL + C to shut down');
-            return cordovaServe.launchBrowser({'target': args.target, 'url': projectUrl});
+            return server.launchBrowser({'target': args.target, 'url': projectUrl});
         })
         .catch(function (error) {
             console.log(error.message || error.toString());


### PR DESCRIPTION
Fixed issue with cordova run/cordova build not working. 

This requires the latest unreleased `cordova-serve` to work. PR for cordova-serve that is required is at https://github.com/apache/cordova-serve/pull/4
