### PR TITLE
CB-13216 Properly install plugin assets

### DIFF
--- a/bin/template/cordova/browser_handler.js
+++ b/bin/template/cordova/browser_handler.js
@@ -111,5 +111,20 @@ module.exports = {
         uninstall: function (obj, project_dir, plugin_id, options) {
             events.emit('verbose', 'lib-file.uninstall is not supported for browser');
         }
+    },
+    asset: {
+        install: function (asset, plugin_dir, wwwDest) {
+            var src = path.join(plugin_dir, asset.src);
+            if (fs.statSync(src).isDirectory()) {
+                src = path.join(src, '*');
+            }
+            var dest = path.join(wwwDest, asset.target);
+
+            shell.cp('-rf', src, dest);
+        },
+        uninstall: function (asset, wwwDest, plugin_id) {
+            shell.rm('-rf', path.join(wwwDest, asset.target));
+            shell.rm('-rf', path.join(wwwDest, 'plugins', plugin_id));
+        }
     }
 };


### PR DESCRIPTION
### Platforms affected
this one

### What does this PR do?
Add support for installing plugin assets.

### What testing has been done on this change?
Added/removed `cordova-plugin-test-framework`.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
