### PR TITLE
CB-13435: fix merges directory support for browser

### DIFF
--- a/bin/template/cordova/Api.js
+++ b/bin/template/cordova/Api.js
@@ -159,7 +159,7 @@ Api.prototype.prepare = function (cordovaProject, options) {
     this.config.write();
 
     // Update own www dir with project's www assets and plugins' assets and js-files
-    this.parser.update_www(cordovaProject.locations.www);
+    this.parser.update_www(cordovaProject, options);
 
     // Copy or Create manifest.json
     // todo: move this to a manifest helper module


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Browser


### What does this PR do?
Fixes merge directory support. https://issues.apache.org/jira/browse/CB-13435

### What testing has been done on this change?


### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
