### PR TITLE
CB-13614: (browser) Fix asset copy bug.

### DIFF
--- a/bin/template/cordova/browser_handler.js
+++ b/bin/template/cordova/browser_handler.js
@@ -120,7 +120,9 @@ module.exports = {
             if (fs.statSync(src).isDirectory()) {
                 shell.cp('-Rf', src + '/*', dest);
             } else {
-                shell.mkdir(path.parse(dest).dir);
+                if (path.parse(asset.target).dir !== '') {
+                    shell.mkdir(path.parse(dest).dir);
+                }
                 shell.cp('-f', src, dest);
             }
         },

--- a/bin/template/cordova/browser_handler.js
+++ b/bin/template/cordova/browser_handler.js
@@ -120,6 +120,7 @@ module.exports = {
             if (fs.statSync(src).isDirectory()) {
                 shell.cp('-Rf', src + '/*', dest);
             } else {
+                shell.mkdir(path.parse(dest).dir);
                 shell.cp('-f', src, dest);
             }
         },

--- a/bin/template/cordova/browser_handler.js
+++ b/bin/template/cordova/browser_handler.js
@@ -121,7 +121,7 @@ module.exports = {
                 shell.cp('-Rf', src + '/*', dest);
             } else {
                 if (path.parse(asset.target).dir !== '') {
-                    shell.mkdir(path.parse(dest).dir);
+                    shell.mkdir('-p', path.parse(dest).dir);
                 }
                 shell.cp('-f', src, dest);
             }

--- a/spec/browser_handler.spec.js
+++ b/spec/browser_handler.spec.js
@@ -63,7 +63,7 @@ describe('Asset install tests', function () {
         };
         spyOn(fs, 'statSync').and.returnValue(fsstatMock);
         browser_handler.asset.install(assetPath, plugin_dir, wwwDest);
-        expect(mkdir).toHaveBeenCalledWith('dest/js/deepdown');
+        expect(mkdir).toHaveBeenCalledWith('-p', 'dest/js/deepdown');
         expect(cp).toHaveBeenCalledWith('-f', 'pluginDir/someSrc/reformat.js', 'dest/js/deepdown/reformat.js');
     });
 });

--- a/spec/browser_handler.spec.js
+++ b/spec/browser_handler.spec.js
@@ -25,9 +25,10 @@ var path = require('path');
 describe('Asset install tests', function () {
     var fsstatMock;
     var asset = { itemType: 'asset', src: 'someSrc/ServiceWorker.js', target: 'ServiceWorker.js' };
+    var assetPath = { itemType: 'asset', src: 'someSrc/reformat.js', target: 'js/deepdown/reformat.js' };
     var plugin_dir = 'pluginDir';
     var wwwDest = 'dest';
-    var cpPath = path.join(plugin_dir, asset.src);
+    // var cpPath = path.join(plugin_dir, asset.src);
 
     it('if src is a directory, should be called with cp, -Rf', function () {
         var cp = spyOn(shell, 'cp').and.returnValue('-Rf');
@@ -40,8 +41,9 @@ describe('Asset install tests', function () {
         browser_handler.asset.install(asset, plugin_dir, wwwDest);
         expect(cp).toHaveBeenCalledWith('-Rf', jasmine.any(String), path.join('dest', asset.target));
     });
-    it('if src is not a directory, should be called with cp, -f', function () {
+    it('if src is not a directory and asset has no path, should be called with cp, -f', function () {
         var cp = spyOn(shell, 'cp').and.returnValue('-f');
+        var mkdir = spyOn(shell, 'mkdir');
         fsstatMock = {
             isDirectory: function () {
                 return false;
@@ -49,6 +51,20 @@ describe('Asset install tests', function () {
         };
         spyOn(fs, 'statSync').and.returnValue(fsstatMock);
         browser_handler.asset.install(asset, plugin_dir, wwwDest);
-        expect(cp).toHaveBeenCalledWith('-f', cpPath, path.join('dest', asset.target));
+        expect(mkdir).not.toHaveBeenCalled();
+        expect(cp).toHaveBeenCalledWith('-f', 'pluginDir/someSrc/ServiceWorker.js', 'dest/ServiceWorker.js');
+    });
+    it('if src is not a directory and asset has a path, should be called with cp, -f', function () {
+        var cp = spyOn(shell, 'cp').and.returnValue('-f');
+        var mkdir = spyOn(shell, 'mkdir');
+        fsstatMock = {
+            isDirectory: function () {
+                return false;
+            }
+        };
+        spyOn(fs, 'statSync').and.returnValue(fsstatMock);
+        browser_handler.asset.install(assetPath, plugin_dir, wwwDest);
+        expect(mkdir).toHaveBeenCalledWith('dest/js/deepdown');
+        expect(cp).toHaveBeenCalledWith('-f', 'pluginDir/someSrc/reformat.js', 'dest/js/deepdown/reformat.js');
     });
 });

--- a/spec/browser_handler.spec.js
+++ b/spec/browser_handler.spec.js
@@ -24,8 +24,8 @@ var path = require('path');
 
 describe('Asset install tests', function () {
     var fsstatMock;
-    var asset = { itemType: 'asset', src: 'someSrc/ServiceWorker.js', target: 'ServiceWorker.js' };
-    var assetPath = { itemType: 'asset', src: 'someSrc/reformat.js', target: 'js/deepdown/reformat.js' };
+    var asset = { itemType: 'asset', src: path.join('someSrc', 'ServiceWorker.js'), target: 'ServiceWorker.js' };
+    var assetWithPath = { itemType: 'asset', src: path.join('someSrc', 'reformat.js'), target: path.join('js', 'deepdown', 'reformat.js') };
     var plugin_dir = 'pluginDir';
     var wwwDest = 'dest';
 
@@ -51,7 +51,7 @@ describe('Asset install tests', function () {
         spyOn(fs, 'statSync').and.returnValue(fsstatMock);
         browser_handler.asset.install(asset, plugin_dir, wwwDest);
         expect(mkdir).not.toHaveBeenCalled();
-        expect(cp).toHaveBeenCalledWith('-f', 'pluginDir/someSrc/ServiceWorker.js', 'dest/ServiceWorker.js');
+        expect(cp).toHaveBeenCalledWith('-f', path.join('pluginDir', 'someSrc', 'ServiceWorker.js'), path.join('dest', 'ServiceWorker.js'));
     });
     it('if src is not a directory and asset has a path, should be called with cp, -f', function () {
         var cp = spyOn(shell, 'cp').and.returnValue('-f');
@@ -62,8 +62,8 @@ describe('Asset install tests', function () {
             }
         };
         spyOn(fs, 'statSync').and.returnValue(fsstatMock);
-        browser_handler.asset.install(assetPath, plugin_dir, wwwDest);
-        expect(mkdir).toHaveBeenCalledWith('-p', 'dest/js/deepdown');
-        expect(cp).toHaveBeenCalledWith('-f', 'pluginDir/someSrc/reformat.js', 'dest/js/deepdown/reformat.js');
+        browser_handler.asset.install(assetWithPath, plugin_dir, wwwDest);
+        expect(mkdir).toHaveBeenCalledWith('-p', path.join('dest', 'js', 'deepdown'));
+        expect(cp).toHaveBeenCalledWith('-f', path.join('pluginDir', 'someSrc', 'reformat.js'), path.join('dest', 'js', 'deepdown', 'reformat.js'));
     });
 });

--- a/spec/browser_handler.spec.js
+++ b/spec/browser_handler.spec.js
@@ -28,7 +28,6 @@ describe('Asset install tests', function () {
     var assetPath = { itemType: 'asset', src: 'someSrc/reformat.js', target: 'js/deepdown/reformat.js' };
     var plugin_dir = 'pluginDir';
     var wwwDest = 'dest';
-    // var cpPath = path.join(plugin_dir, asset.src);
 
     it('if src is a directory, should be called with cp, -Rf', function () {
         var cp = spyOn(shell, 'cp').and.returnValue('-Rf');


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected

browser

### What does this PR do?

Fixes a bug that prevented assets from the plugin file from copying over correctly if the asset contained a path.

### What testing has been done on this change?

I tested the cordova-browser with this patch against my own build and verified that the assets copied correctly, both at the root level and with a path.

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] Added automated test coverage as appropriate for this change.