### PR TITLE
CB-13999: (browser) - Reading config.xml respects base href

### DIFF
--- a/cordova-js-src/confighelper.js
+++ b/cordova-js-src/confighelper.js
@@ -66,7 +66,7 @@ function readConfig(success, error) {
 
 
     try {
-        xhr.open("get", "/config.xml", true);
+        xhr.open("get", "config.xml", true);
         xhr.send();
     } catch(e) {
         fail('[Browser][cordova.js][readConfig] Could not XHR config.xml: ' + JSON.stringify(e));


### PR DESCRIPTION
### Platforms affected
Browser

### What does this PR do?
Causes xhr that gets the config.xml file to respect the base href (if set) in the index.html

### What testing has been done on this change?
Manual testing

### Checklist
- [X] [[Reported an issue]](https://issues.apache.org/jira/browse/CB-13999)
- [X] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [X] Added automated test coverage as appropriate for this change.
