### PR TITLE
CB-14073 browser: Drop Node 4, Added Node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: node_js
 sudo: false
+
 node_js:
-  - "4"
   - "6"
   - "8"
+  - "10"
+
 install:
   - npm install
+
 script:
   - node --version
   - npm --version
   - npm test
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,9 @@
 
 environment:
   matrix:
-  - nodejs_version: "4"
   - nodejs_version: "6"
   - nodejs_version: "8"
+  - nodejs_version: "10"
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=4.0.0"
+    "node": ">=6.0.0"
   },
   "engineStrict": true
 }


### PR DESCRIPTION
### Platforms affected
browser

### What does this PR do?
- Drop Node 4 Support
- Added Node 10 Support

### What testing has been done on this change?
- `npm run jasmine`
- https://travis-ci.org/erisu/cordova-browser/builds/427072902

### Checklist
- [x] [Reported an issue](http://cordova.apache.org/contribute/issues.html) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [ ] Added automated test coverage as appropriate for this change.
