### PR TITLE
CB-13999: (browser) - Reading config.xml respects base href

### DIFF
--- a/cordova-lib/cordova.js
+++ b/cordova-lib/cordova.js
@@ -886,7 +886,7 @@ function readConfig(success, error) {
 
 
     try {
-        xhr.open("get", "/config.xml", true);
+        xhr.open("get", "config.xml", true);
         xhr.send();
     } catch(e) {
         fail('[Browser][cordova.js][readConfig] Could not XHR config.xml: ' + JSON.stringify(e));


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist
is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Browser

### What does this PR do?
Link to config.xml using the base href instead of the root (removed the trailing /)

### What testing has been done on this change?
Manual testing in an Ionic/Cordova project

### Checklist
- [x] [Reported an issue](https://issues.apache.org/jira/browse/CB-13999) in the JIRA database
- [x] Commit message follows the format: "CB-3232: (android) Fix bug with resolving file paths", where CB-xxxx is the JIRA ID & "android" is the platform affected.
- [x] ~~Added automated test coverage as appropriate for this change.~~
