### PR TITLE
Only copy platform node_modules when created by binary

### DIFF
--- a/bin/create
+++ b/bin/create
@@ -85,6 +85,7 @@ else {
         cli: argv.cli,
         link: argv.link || argv.shared,
         customTemplate: argv.argv.remain[3],
+        copyPlatformNodeModules: true
     };
 
     Api.createPlatform(projectPath, config, options);

--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -27,7 +27,7 @@ var events = require('cordova-common').events;
 var check_reqs = require('./check_reqs');
 
 // exported method to create a project, returns a promise that resolves with null
-module.exports.createProject = function (project_path, package_name, project_name) {
+module.exports.createProject = function (project_path, package_name, project_name, options) {
 /*
     // create the dest and the standard place for our api to live
     // platforms/platformName/cordova/Api.js
@@ -58,8 +58,7 @@ module.exports.createProject = function (project_path, package_name, project_nam
     shell.cp('-r', path.join(ROOT, 'bin/template/www'), project_path);
 
     // recreate our node_modules structure in the new project
-    shell.cp('-r', path.join(ROOT, 'node_modules'),
-        path.join(project_path, 'cordova'));
+    if (options && options.copyPlatformNodeModules) shell.cp('-r', path.join(ROOT, 'node_modules'), path.join(project_path, 'cordova'));
 
     // copy check_reqs file
     shell.cp(path.join(ROOT, 'bin/lib/check_reqs.js'),


### PR DESCRIPTION
### Platforms affected
Browser

### What does this PR do?
When platform is installed though CLI, `cordova platform add browser`, the copy node_modules step is no longer valid as dependencies are now at the project level.

The step is required only when the create binary from the platform repo is called.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm t
- https://travis-ci.org/erisu/cordova-browser/builds/452143904