### PR TITLE
Dependency bump cordova-common@^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "npm run eslint && npm run jasmine"
   },
   "dependencies": {
-    "cordova-common": "^2.1.1",
+    "cordova-common": "^3.0.0",
     "cordova-serve": "^2.0.0",
     "nopt": "^3.0.6",
     "shelljs": "^0.5.3"


### PR DESCRIPTION
### Platforms affected
browser

### What does this PR do?
Updates the cordova-common dependency to ^3.0.0.

### What testing has been done on this change?
- Travis CI Testing: https://travis-ci.org/erisu/cordova-browser/builds/452165028