### PR TITLE
Copy node_modules if the directory exists

### DIFF
--- a/bin/lib/create.js
+++ b/bin/lib/create.js
@@ -58,8 +58,8 @@ module.exports.createProject = function (project_path, package_name, project_nam
     shell.cp('-r', path.join(ROOT, 'bin/template/www'), project_path);
 
     // recreate our node_modules structure in the new project
-    shell.cp('-r', path.join(ROOT, 'node_modules'),
-        path.join(project_path, 'cordova'));
+    let nodeModulesDir = path.join(ROOT, 'node_modules');
+    if (fs.existsSync(nodeModulesDir)) shell.cp('-r', nodeModulesDir, path.join(project_path, 'cordova'));
 
     // copy check_reqs file
     shell.cp(path.join(ROOT, 'bin/lib/check_reqs.js'),


### PR DESCRIPTION
### Platforms affected
browser

### What does this PR do?
- Copy the platform node_modules only when the folder exists.

https://github.com/apache/cordova/issues/32

### What testing has been done on this change?
- npm t