### PR TITLE
Browser Platform Release Preparation (Cordova 9)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ temp
 *.jar
 .vscode
 node_modules/
+coverage/
+.nyc_output/

--- a/bin/template/cordova/Api.js
+++ b/bin/template/cordova/Api.js
@@ -211,9 +211,9 @@ Api.prototype.prepare = function (cordovaProject, options) {
                     "sizes": "128x128"
                 } ******/
                 // ?Is it worth looking at file extentions?
-                return {'src': icon.src,
+                return { 'src': icon.src,
                     'type': 'image/png',
-                    'sizes': (icon.width + 'x' + icon.height)};
+                    'sizes': (icon.width + 'x' + icon.height) };
             });
             manifestJson.icons = manifestIcons;
 
@@ -230,7 +230,7 @@ Api.prototype.prepare = function (cordovaProject, options) {
             }
 
             // get start_url
-            var contentNode = this.config.doc.find('content') || {'attrib': {'src': 'index.html'}}; // sensible default
+            var contentNode = this.config.doc.find('content') || { 'attrib': { 'src': 'index.html' } }; // sensible default
             manifestJson.start_url = contentNode.attrib.src;
 
             // now we get some values from start_url page ...

--- a/bin/template/cordova/lib/run.js
+++ b/bin/template/cordova/lib/run.js
@@ -46,16 +46,18 @@ module.exports.run = function (args) {
     }
 
     var server = cordovaServe();
-    server.servePlatform('browser', {port: args.port, noServerInfo: true, noLogOutput: args.noLogOutput})
+    server.servePlatform('browser', { port: args.port, noServerInfo: true, noLogOutput: args.noLogOutput })
         .then(function () {
             if (!startPage) {
                 // failing all else, set the default
                 startPage = 'index.html';
             }
-            var projectUrl = url.resolve('http://localhost:' + server.port + '/', startPage);
+
+            var projectUrl = (new url.URL(`http://localhost:${server.port}/${startPage}`)).href;
+
             console.log('startPage = ' + startPage);
             console.log('Static file server running @ ' + projectUrl + '\nCTRL + C to shut down');
-            return server.launchBrowser({'target': args.target, 'url': projectUrl});
+            return server.launchBrowser({ 'target': args.target, 'url': projectUrl });
         })
         .catch(function (error) {
             console.log(error.message || error.toString());

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "cover": "nyc jasmine",
     "eslint": "eslint bin spec",
     "jasmine": "jasmine",
-    "test": "npm run eslint && npm run jasmine"
+    "test": "npm run eslint && npm run cover"
   },
   "dependencies": {
     "cordova-common": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "eslint-plugin-node": "^8.0.1",
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
-    "jasmine": "^2.5.3",
-    "tmp": "^0.0.26"
+    "jasmine": "^3.3.1",
+    "tmp": "0.0.33"
   },
   "author": "Apache Software Foundation",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "cordova-common": "^3.0.0",
     "cordova-serve": "^2.0.0",
-    "nopt": "^3.0.6",
+    "nopt": "^4.0.1",
     "shelljs": "^0.5.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
     "test": "npm run eslint && npm run jasmine"
   },
   "dependencies": {
-    "cordova-common": "^3.0.0",
-    "cordova-serve": "^2.0.0",
+    "cordova-common": "^3.1.0",
+    "cordova-serve": "^3.0.0",
     "nopt": "^4.0.1",
     "shelljs": "^0.5.3"
   },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "apache"
   ],
   "scripts": {
-    "eslint": "eslint bin && eslint spec",
+    "eslint": "eslint bin spec",
     "jasmine": "jasmine",
     "test": "npm run eslint && npm run jasmine"
   },
@@ -28,13 +28,13 @@
     "shelljs": "^0.5.3"
   },
   "devDependencies": {
-    "eslint": "^4.0.0",
-    "eslint-config-semistandard": "^11.0.0",
-    "eslint-config-standard": "^10.2.1",
-    "eslint-plugin-import": "^2.3.0",
-    "eslint-plugin-node": "^5.0.0",
-    "eslint-plugin-promise": "^3.5.0",
-    "eslint-plugin-standard": "^3.0.1",
+    "eslint": "^5.12.0",
+    "eslint-config-semistandard": "^13.0.0",
+    "eslint-config-standard": "^12.0.0",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-node": "^8.0.1",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^2.5.3",
     "tmp": "^0.0.26"
   },

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/apache/cordova-browser"
   },
   "bugs": {
-    "url": "https://issues.apache.org/jira/browse/CB"
+    "url": "https://github.com/apache/cordova-browser/issues"
   },
   "keywords": [
     "cordova",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "apache"
   ],
   "scripts": {
+    "cover": "nyc jasmine",
     "eslint": "eslint bin spec",
     "jasmine": "jasmine",
     "test": "npm run eslint && npm run jasmine"
@@ -36,6 +37,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
+    "nyc": "^13.1.0",
     "tmp": "0.0.33"
   },
   "author": "Apache Software Foundation",
@@ -57,5 +59,15 @@
   "engines": {
     "node": ">=6.0.0"
   },
-  "engineStrict": true
+  "engineStrict": true,
+  "nyc": {
+    "include": [
+      "bin/lib/**",
+      "bin/templates/cordova/**"
+    ],
+    "reporter": [
+      "lcov",
+      "text"
+    ]
+  }
 }


### PR DESCRIPTION
### Platforms affected
browser

### What does this PR do?
This PR contains final preparations for the Cordova 9 release goals. 

See [Cordova 9 Release Plan](https://github.com/apache/cordova/issues/10).
 
- Bumped Cordova Dependencies
  - `cordova-common@^3.1.0`
  - `cordova-serve@^3.0.0`
- Bumped ESLint dependencies with correction
  - `eslint@^5.12.0`
  - `eslint-config-semistandard@^13.0.0`
  - `eslint-config-standard@^12.0.0`
  - `eslint-plugin-import@^2.14.0`
  - `eslint-plugin-node@^8.0.1`
  - `eslint-plugin-promise@^4.0.1`
  - `eslint-plugin-standard@^4.0.0`
- Bumped Dev Dependencies
  - `jasmine@^3.3.1`
  - `tmp@0.0.33`
- Updated Dependencies
  - `nopt@^4.0.1`
- Added nyc code coverage dependency

### What testing has been done on this change?
- `npm t`
  - ESLint
  - Jasmine unit testing
- [Travis CI](https://travis-ci.org/erisu/cordova-browser/builds/478166835)
- Platform Add & Prepare
  ```
  $ npx cordova@nightly create browserTest com.foobar.browserTest
  $ cd ./browserTest
  $ npx cordova@nightly platform add github:erisu/cordova-browser\#cordova9-prep
  $ npx cordova@nightly run browser
  $ npx cordova@nightly run browser --port=81
  $ npx cordova@nightly build browser
  ```