### PR TITLE
Remove Q for Native Promise

### DIFF
--- a/bin/lib/update.js
+++ b/bin/lib/update.js
@@ -17,10 +17,10 @@
        under the License.
 */
 
-var Q = require('q');
 var create = require('./create');
 var fs = require('fs');
 var shell = require('shelljs');
+const { CordovaError } = require('cordova-common');
 
 module.exports.help = function () {
     console.log('WARNING : Make sure to back up your project before updating!');
@@ -32,15 +32,17 @@ module.exports.help = function () {
 
 module.exports.run = function (argv) {
     var projectPath = argv[2];
+
+    // If the specified project path is not valid then reject promise.
     if (!fs.existsSync(projectPath)) {
-        // if specified project path is not valid then reject promise
-        Q.reject('Browser platform does not exist here: ' + projectPath);
+        return Promise.reject(new CordovaError(`Browser platform does not exist here: ${projectPath}`));
     }
-    return Q().then(function () {
-        console.log('Removing existing browser platform.');
-        shellfatal(shell.rm, '-rf', projectPath);
-        create.createProject(projectPath);
-    });
+
+    console.log('Removing existing browser platform.');
+    shellfatal(shell.rm, '-rf', projectPath);
+
+    // Create Project returns a resolved promise.
+    return create.createProject(projectPath);
 };
 
 function shellfatal (shellFunc) {

--- a/bin/update
+++ b/bin/update
@@ -24,9 +24,9 @@ var update = require('./lib/update');
 if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) > -1) {
     update.help();
 } else {
-    update.run(process.argv).done(function () {
+    update.run(process.argv).then(() => {
         console.log('Successfully updated browser project.');
-    }, function (err) {
+    }, (err) => {
         console.error('Update failed due to', err);
         process.exit(2);
     });

--- a/bin/update
+++ b/bin/update
@@ -26,7 +26,7 @@ if (['--help', '/?', '-h', 'help', '-help', '/help'].indexOf(process.argv[2]) > 
 } else {
     update.run(process.argv).then(() => {
         console.log('Successfully updated browser project.');
-    }, (err) => {
+    }, err => {
         console.error('Update failed due to', err);
         process.exit(2);
     });


### PR DESCRIPTION
### Platforms affected
browser

### Motivation and Context
Remove `Q` Efforts: https://github.com/apache/cordova/issues/7

### Description
This repo did not have the `Q` dependency defined explicit in `package.json` but was still using `Q` that would have been a sub-dependency of `cordova-common`.

This PR removes the only usage of `Q`.

### Testing
- `npm t`

- Update with Good Project Path
```
$ ./cordova-browser/bin/update /cordova/projectPath
Removing existing browser platform.
Successfully updated browser project.
```

- Update with Bad Path
```
$ ./cordova-browser/bin/update /cordova/fakepath
Update failed due to CordovaError: Browser platform does not exist here: /cordova/fakepath_
    at Object.module.exports.run (/cordova/cordova-browser/bin/lib/update.js:38:31)
    at Object.<anonymous> (/cordova/cordova-browser/bin/update:27:12)
    at Module._compile (internal/modules/cjs/loader.js:774:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:785:10)
    at Module.load (internal/modules/cjs/loader.js:641:32)
    at Function.Module._load (internal/modules/cjs/loader.js:556:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:837:10)
    at internal/main/run_main_module.js:17:11 {
  name: 'CordovaError',
  message: 'Browser platform does not exist here: ' +
    '/cordova/.testsss_',
  code: 0,
  context: undefined
}

```

### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
