### PR TITLE
chore: update nyc dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
-    "nyc": "^13.1.0",
+    "nyc": "^14.1.1",
     "tmp": "0.0.33"
   },
   "author": "Apache Software Foundation",


### PR DESCRIPTION
### Motivation and Context

Use current version of `nyc` to resolve a bug that was seen with v13.x on Windows with node >= 10.

### Description

Update `nyc` dev dependency
