### PR TITLE
Fix for issues with 'cordova run' command.

### DIFF
--- a/bin/template/cordova/lib/run.js
+++ b/bin/template/cordova/lib/run.js
@@ -26,9 +26,9 @@ var cordovaServe = require('cordova-serve');
 
 module.exports.run = function (args) {
     // defaults
-    args.port = args.port || 8000;
-    args.target = args.target || 'default'; // make default the system browser
-    args.noLogOutput = args.silent || false;
+    var port = args.port || 8000;
+    var target = args.target || 'default'; // make default the system browser
+    var noLogOutput = args.silent || false;
 
     var wwwPath = path.join(__dirname, '../../www');
     var manifestFilePath = path.resolve(path.join(wwwPath, 'manifest.json'));
@@ -46,7 +46,7 @@ module.exports.run = function (args) {
     }
 
     var server = cordovaServe();
-    server.servePlatform('browser', { port: args.port, noServerInfo: true, noLogOutput: args.noLogOutput })
+    server.servePlatform('browser', { port: port, noServerInfo: true, noLogOutput: noLogOutput })
         .then(function () {
             if (!startPage) {
                 // failing all else, set the default
@@ -57,7 +57,7 @@ module.exports.run = function (args) {
 
             console.log('startPage = ' + startPage);
             console.log('Static file server running @ ' + projectUrl + '\nCTRL + C to shut down');
-            return server.launchBrowser({ 'target': args.target, 'url': projectUrl });
+            return server.launchBrowser({ 'target': target, 'url': projectUrl });
         })
         .catch(function (error) {
             console.log(error.message || error.toString());


### PR DESCRIPTION
Do not change values of args since it's used from the rest of platforms during 'cordova run' command execution which runs all platforms.

<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected


### Motivation and Context
#87 



### Description
fixes #87


### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [x] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
