### PR TITLE
ci: removes Node.js v6 and v8 from testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: node_js
 sudo: false
 
 node_js:
-  - 6
-  - 8
   - 10
   - 12
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,16 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 
-
 # appveyor file
 # http://www.appveyor.com/docs/appveyor-yml
 
 environment:
   matrix:
-  - nodejs_version: 6
-  - nodejs_version: 8
-  - nodejs_version: 10
-  - nodejs_version: 12
+    - nodejs_version: "10"
+    - nodejs_version: "12"
 
 install:
   - ps: Install-Product node $env:nodejs_version


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected



### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->



### Description
<!-- Describe your changes in detail -->



### Testing
<!-- Please describe in detail how you tested your changes. -->



### Checklist

- [ ] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [ ] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [ ] I've updated the documentation if necessary
