### PR TITLE
breaking: replace shelljs w/ fs-extra where possible

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -230,37 +230,6 @@ OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
-node_modules/shelljs
-================================================================================
-
-Copyright (c) 2012, Artur Adib <aadib@mozilla.com>
-All rights reserved.
-
-You may use this project under the terms of the New BSD license as follows:
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-      notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Artur Adib nor the
-      names of the contributors may be used to endorse or promote products
-      derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL ARTUR ADIB BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-================================================================================
 node_modules/nopt
 ================================================================================
 

--- a/bin/lib/update.js
+++ b/bin/lib/update.js
@@ -18,8 +18,7 @@
 */
 
 var create = require('./create');
-var fs = require('fs');
-var shell = require('shelljs');
+var fs = require('fs-extra');
 const { CordovaError } = require('cordova-common');
 
 module.exports.help = function () {
@@ -39,20 +38,8 @@ module.exports.run = function (argv) {
     }
 
     console.log('Removing existing browser platform.');
-    shellfatal(shell.rm, '-rf', projectPath);
+    fs.removeSync(projectPath);
 
     // Create Project returns a resolved promise.
     return create.createProject(projectPath);
 };
-
-function shellfatal (shellFunc) {
-    var slicedArgs = Array.prototype.slice.call(arguments, 1);
-    var returnVal = null;
-    try {
-        shell.config.fatal = true;
-        returnVal = shellFunc.apply(shell, slicedArgs);
-    } finally {
-        shell.config.fatal = false;
-    }
-    return returnVal;
-}

--- a/bin/template/cordova/Api.js
+++ b/bin/template/cordova/Api.js
@@ -22,9 +22,8 @@ under the License.
     'cordova platform add PATH' where path is this repo.
 */
 
-var shell = require('shelljs');
 var path = require('path');
-var fs = require('fs');
+var fs = require('fs-extra');
 
 var cdvcmn = require('cordova-common');
 var CordovaLogger = cdvcmn.CordovaLogger;
@@ -132,8 +131,7 @@ Api.prototype.getPlatformInfo = function () {
 Api.prototype.prepare = function (cordovaProject, options) {
 
     // First cleanup current config and merge project's one into own
-    var defaultConfigPath = path.join(this.locations.platformRootDir, 'cordova',
-        'defaults.xml');
+    var defaultConfigPath = path.join(this.locations.platformRootDir, 'cordova', 'defaults.xml');
     var ownConfigPath = this.locations.configXml;
     var sourceCfg = cordovaProject.projectConfig;
 
@@ -142,13 +140,13 @@ Api.prototype.prepare = function (cordovaProject, options) {
     // restored or copy project config into platform if none exists.
     if (fs.existsSync(defaultConfigPath)) {
         this.events.emit('verbose', 'Generating config.xml from defaults for platform "' + this.platform + '"');
-        shell.cp('-f', defaultConfigPath, ownConfigPath);
+        fs.copySync(defaultConfigPath, ownConfigPath);
     } else if (fs.existsSync(ownConfigPath)) {
-        this.events.emit('verbose', 'Generating defaults.xml from own config.xml for platform "' + this.platform + '"');
-        shell.cp('-f', ownConfigPath, defaultConfigPath);
+        this.events.emit('verbose', `Generating defaults.xml from own config.xml for platform "${this.platform}"`);
+        fs.copySync(ownConfigPath, defaultConfigPath);
     } else {
-        this.events.emit('verbose', 'case 3"' + this.platform + '"');
-        shell.cp('-f', sourceCfg.path, ownConfigPath);
+        this.events.emit('verbose', `case 3 "${this.platform}"`);
+        fs.copySync(sourceCfg.path, ownConfigPath);
     }
 
     // merge our configs
@@ -170,7 +168,7 @@ Api.prototype.prepare = function (cordovaProject, options) {
         // just blindly copy it to our output/www
         // todo: validate it? ensure all properties we expect exist?
         this.events.emit('verbose', 'copying ' + srcManifestPath + ' => ' + manifestPath);
-        shell.cp('-f', srcManifestPath, manifestPath);
+        fs.copySync(srcManifestPath, manifestPath);
     } else {
         var manifestJson = {
             'background_color': '#FFF',
@@ -357,7 +355,7 @@ Api.prototype.removePlugin = function (plugin, uninstallOptions) {
             self._removeModulesInfo(plugin, targetDir);
             // Remove stale plugin directory
             // TODO: this should be done by plugin files uninstaller
-            shell.rm('-rf', path.resolve(self.root, 'Plugins', plugin.id));
+            fs.removeSync(path.resolve(self.root, 'Plugins', plugin.id));
         });
 };
 
@@ -474,7 +472,7 @@ Api.prototype._writePluginModules = function (targetDir) {
     final_contents += '// BOTTOM OF METADATA\n';
     final_contents += '});'; // Close cordova.define.
 
-    shell.mkdir('-p', targetDir);
+    fs.ensureDirSync(targetDir);
     fs.writeFileSync(path.join(targetDir, 'cordova_plugins.js'), final_contents, 'utf-8');
 };
 

--- a/bin/template/cordova/browser_handler.js
+++ b/bin/template/cordova/browser_handler.js
@@ -18,8 +18,7 @@
 */
 
 var path = require('path');
-var fs = require('fs');
-var shell = require('shelljs');
+var fs = require('fs-extra');
 var events = require('cordova-common').events;
 
 module.exports = {
@@ -59,7 +58,7 @@ module.exports = {
             scriptContent = 'cordova.define("' + moduleName + '", function(require, exports, module) { ' + scriptContent + '\n});\n';
 
             var moduleDestination = path.resolve(www_dir, 'plugins', plugin_id, jsModule.src);
-            shell.mkdir('-p', path.dirname(moduleDestination));
+            fs.ensureDirSync(path.dirname(moduleDestination));
             fs.writeFileSync(moduleDestination, scriptContent, 'utf-8');
         },
         uninstall: function (jsModule, www_dir, plugin_id) {
@@ -117,19 +116,13 @@ module.exports = {
             var src = path.join(plugin_dir, asset.src);
             var dest = path.join(wwwDest, asset.target);
             var destDir = path.parse(dest).dir;
-            if (destDir !== '' && !fs.existsSync(destDir)) {
-                shell.mkdir('-p', destDir);
-            }
 
-            if (fs.statSync(src).isDirectory()) {
-                shell.cp('-Rf', src + '/*', dest);
-            } else {
-                shell.cp('-f', src, dest);
-            }
+            fs.ensureDirSync(destDir);
+            fs.copySync(src, dest);
         },
         uninstall: function (asset, wwwDest, plugin_id) {
-            shell.rm('-rf', path.join(wwwDest, asset.target));
-            shell.rm('-rf', path.join(wwwDest, 'plugins', plugin_id));
+            fs.removeSync(path.join(wwwDest, asset.target));
+            fs.removeSync(path.join(wwwDest, 'plugins', plugin_id));
         }
     }
 };

--- a/bin/template/cordova/browser_parser.js
+++ b/bin/template/cordova/browser_parser.js
@@ -17,9 +17,8 @@
     under the License.
 */
 
-var fs = require('fs');
+var fs = require('fs-extra');
 var path = require('path');
-var shell = require('shelljs');
 var CordovaError = require('cordova-common').CordovaError;
 var events = require('cordova-common').events;
 var FileUpdater = require('cordova-common').FileUpdater;
@@ -89,17 +88,8 @@ browser_parser.prototype.update_www = function (cordovaProject, opts) {
     FileUpdater.mergeAndUpdateDir(sourceDirs, targetDir, { rootDir: cordovaProject.root }, logFileOp);
 };
 
-browser_parser.prototype.update_overrides = function () {
-    // console.log("update_overrides");
-
-    // TODO: ?
-    // var projectRoot = util.isCordova(this.path);
-    // var mergesPath = path.join(util.appDir(projectRoot), 'merges', 'browser');
-    // if(fs.existsSync(mergesPath)) {
-    //     var overrides = path.join(mergesPath, '*');
-    //     shell.cp('-rf', overrides, this.www_dir());
-    // }
-};
+// @todo ?
+browser_parser.prototype.update_overrides = function () { };
 
 browser_parser.prototype.config_xml = function () {
     return path.join(this.path, 'config.xml');
@@ -114,7 +104,7 @@ browser_parser.prototype.update_project = function (cfg) {
     defer.then(function () {
         self.update_overrides();
         // Copy munged config.xml to platform www dir
-        shell.cp('-rf', path.join(www_dir, '..', 'config.xml'), www_dir);
+        fs.copySync(path.join(www_dir, '..', 'config.xml'), path.join(www_dir, 'config.xml'));
     });
     return defer;
 };

--- a/bin/template/cordova/lib/clean.js
+++ b/bin/template/cordova/lib/clean.js
@@ -19,8 +19,7 @@
  * under the License.
  */
 
-var fs = require('fs');
-var shell = require('shelljs');
+var fs = require('fs-extra');
 var path = require('path');
 var check_reqs = require('./check_reqs');
 var platformBuildDir = path.join('platforms', 'browser', 'www');
@@ -36,7 +35,7 @@ var run = function () {
 
     try {
         if (fs.existsSync(platformBuildDir)) {
-            shell.rm('-r', platformBuildDir);
+            fs.removeSync(platformBuildDir);
         }
     } catch (err) {
         console.log('could not remove ' + platformBuildDir + ' : ' + err.message);

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
     "cordova-common": "^3.1.0",
     "cordova-serve": "^3.0.0",
     "fs-extra": "^9.0.0",
-    "nopt": "^4.0.1",
-    "shelljs": "^0.5.3"
+    "nopt": "^4.0.1"
   },
   "devDependencies": {
     "eslint": "^5.12.0",
@@ -39,6 +38,7 @@
     "eslint-plugin-standard": "^4.0.0",
     "jasmine": "^3.3.1",
     "nyc": "^14.1.1",
+    "shelljs": "^0.8.4",
     "tmp": "0.0.33"
   },
   "author": "Apache Software Foundation",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "cordova-common": "^3.1.0",
     "cordova-serve": "^3.0.0",
+    "fs-extra": "^9.0.0",
     "nopt": "^4.0.1",
     "shelljs": "^0.5.3"
   },

--- a/spec/manifest.spec.js
+++ b/spec/manifest.spec.js
@@ -17,8 +17,8 @@
  under the License.
  */
 
-var shell = require('shelljs');
-var fs = require('fs');
+var { exec } = require('shelljs');
+var fs = require('fs-extra');
 var path = require('path');
 var util = require('util');
 
@@ -32,13 +32,13 @@ function createAndBuild (projectname, projectid) {
     var command;
 
     // remove existing folder
-    shell.rm('-rf', tmpDir);
-    shell.mkdir(tmpDir);
+    fs.removeSync(tmpDir);
+    fs.ensureDirSync(tmpDir);
 
     // create the project
     command = util.format('"%s" "%s/%s" "%s" "%s"', createScriptPath, tmpDir, projectname, projectid, projectname);
 
-    return_code = shell.exec(command).code;
+    return_code = exec(command).code;
     expect(return_code).toBe(0);
 
     var platWwwPath = path.join(tmpDir, projectname, 'platform_www');
@@ -71,7 +71,7 @@ function createAndBuild (projectname, projectid) {
     // related_applications[{platform:'web'},{platform:'play',url:...}] ?
 
     // clean-up
-    shell.rm('-rf', tmpDir);
+    fs.removeSync(tmpDir);
 }
 
 describe('create', function () {


### PR DESCRIPTION
### Motivation, Context & Description

* Added `fs-extra` as release dependency
* Replace `shelljs` with `fs-extra` where possible.
* Remove `shelljs` as release dependency

### Testing

* `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
