### PR TITLE
breaking: bump cordova dependencies to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "test": "npm run eslint && npm run cover"
   },
   "dependencies": {
-    "cordova-common": "^3.1.0",
-    "cordova-serve": "^3.0.0",
+    "cordova-common": "^4.0.0",
+    "cordova-serve": "^4.0.0",
     "nopt": "^4.0.1",
     "shelljs": "^0.5.3"
   },


### PR DESCRIPTION
### Motivation and Context

Use latest Cordova dependencies.

### Testing

- `npm t`

### Checklist

- [x] I've run the tests to see all new and existing tests pass
