### PR TITLE
Inline browser_parser into Api

### DIFF
--- a/bin/template/cordova/Api.js
+++ b/bin/template/cordova/Api.js
@@ -35,8 +35,9 @@ const xmlHelpers = cdvcmn.xmlHelpers;
 const PlatformJson = cdvcmn.PlatformJson;
 const PlatformMunger = cdvcmn.ConfigChanges.PlatformMunger;
 const PluginInfoProvider = cdvcmn.PluginInfoProvider;
+const CordovaError = cdvcmn.CordovaError;
+const FileUpdater = cdvcmn.FileUpdater;
 
-const BrowserParser = require('./browser_parser');
 const PLATFORM_NAME = 'browser';
 
 function setupEvents (externalEventEmitter) {
@@ -52,13 +53,26 @@ function setupEvents (externalEventEmitter) {
     return selfEvents;
 }
 
+/**
+ * Logs all file operations via the verbose event stream, indented.
+ */
+function logFileOp (message) {
+    selfEvents.emit('verbose', '  ' + message);
+}
+
+function dirExists (dir) {
+    return fs.existsSync(dir) && fs.statSync(dir).isDirectory();
+}
+
 function Api (platform, platformRootDir, events) {
     this.platform = platform || PLATFORM_NAME;
 
     // MyApp/platforms/browser
     this.root = path.resolve(__dirname, '..');
     this.events = setupEvents(events);
-    this.parser = new BrowserParser(this.root);
+    if (!dirExists(this.root) || !dirExists(path.join(this.root, 'cordova'))) {
+        throw new CordovaError('The provided path "' + this.root + '" is not a valid browser project.');
+    }
     this._handler = require('./browser_handler');
 
     this.locations = {
@@ -127,7 +141,7 @@ Api.prototype.getPlatformInfo = function () {
     };
 };
 
-Api.prototype.prepare = function (cordovaProject, options) {
+Api.prototype.prepare = async function (cordovaProject, options) {
     // First cleanup current config and merge project's one into own
     const defaultConfigPath = path.join(this.locations.platformRootDir, 'cordova',
         'defaults.xml');
@@ -156,7 +170,7 @@ Api.prototype.prepare = function (cordovaProject, options) {
     this.config.write();
 
     // Update own www dir with project's www assets and plugins' assets and js-files
-    this.parser.update_www(cordovaProject, options);
+    this._updateWww(cordovaProject);
 
     // Copy or Create manifest.json
     // todo: move this to a manifest helper module
@@ -254,8 +268,30 @@ Api.prototype.prepare = function (cordovaProject, options) {
         fs.writeFileSync(manifestPath, JSON.stringify(manifestJson, null, 2), 'utf8');
     }
 
-    // update project according to config.xml changes.
-    return this.parser.update_project(this.config, options);
+    // Copy munged config.xml to platform www dir
+    shell.cp('-rf', this.locations.configXml, this.locations.www);
+};
+
+// Replace the www dir with contents of platform_www and app www.
+Api.prototype._updateWww = function (cordovaProject) {
+    // add cordova www and platform_www to sourceDirs
+    const sourceDirs = [
+        path.relative(cordovaProject.root, cordovaProject.locations.www),
+        path.relative(cordovaProject.root, this.locations.platformWww)
+    ];
+
+    // If project contains 'merges' for our platform, use them as another overrides
+    const merges_path = path.join(cordovaProject.root, 'merges', 'browser');
+    if (fs.existsSync(merges_path)) {
+        selfEvents.emit('verbose', 'Found "merges/browser" folder. Copying its contents into the browser project.');
+        // add merges/browser to sourceDirs
+        sourceDirs.push(path.join('merges', 'browser'));
+    }
+
+    // targetDir points to browser/www
+    const targetDir = path.relative(cordovaProject.root, this.locations.www);
+    selfEvents.emit('verbose', 'Merging and updating files from [' + sourceDirs.join(', ') + '] to ' + targetDir);
+    FileUpdater.mergeAndUpdateDir(sourceDirs, targetDir, { rootDir: cordovaProject.root }, logFileOp);
 };
 
 Api.prototype.addPlugin = function (pluginInfo, installOptions) {

--- a/bin/template/cordova/browser_parser.js
+++ b/bin/template/cordova/browser_parser.js
@@ -37,25 +37,8 @@ function browser_parser (project) {
 
 module.exports = browser_parser;
 
-// Returns a promise.
-browser_parser.prototype.update_from_config = function () {
-    return Promise.resolve();
-};
-
 browser_parser.prototype.www_dir = function () {
     return path.join(this.path, 'www');
-};
-
-// Used for creating platform_www in projects created by older versions.
-browser_parser.prototype.cordovajs_path = function (libDir) {
-    const jsPath = path.join(libDir, 'cordova-lib', 'cordova.js');
-    return path.resolve(jsPath);
-};
-
-browser_parser.prototype.cordovajs_src_path = function (libDir) {
-    // console.log("cordovajs_src_path");
-    const jsPath = path.join(libDir, 'cordova-js-src');
-    return path.resolve(jsPath);
 };
 
 /**
@@ -89,32 +72,11 @@ browser_parser.prototype.update_www = function (cordovaProject, opts) {
     FileUpdater.mergeAndUpdateDir(sourceDirs, targetDir, { rootDir: cordovaProject.root }, logFileOp);
 };
 
-browser_parser.prototype.update_overrides = function () {
-    // console.log("update_overrides");
-
-    // TODO: ?
-    // var projectRoot = util.isCordova(this.path);
-    // var mergesPath = path.join(util.appDir(projectRoot), 'merges', 'browser');
-    // if(fs.existsSync(mergesPath)) {
-    //     var overrides = path.join(mergesPath, '*');
-    //     shell.cp('-rf', overrides, this.www_dir());
-    // }
-};
-
 browser_parser.prototype.config_xml = function () {
     return path.join(this.path, 'config.xml');
 };
 
-// Returns a promise.
-browser_parser.prototype.update_project = function (cfg) {
-    // console.log("update_project ",cfg);
-    const defer = this.update_from_config();
-    const self = this;
-    const www_dir = self.www_dir();
-    defer.then(function () {
-        self.update_overrides();
-        // Copy munged config.xml to platform www dir
-        shell.cp('-rf', path.join(www_dir, '..', 'config.xml'), www_dir);
-    });
-    return defer;
+browser_parser.prototype.update_project = async function (cfg) {
+    // Copy munged config.xml to platform www dir
+    shell.cp('-rf', this.config_xml(), this.www_dir());
 };


### PR DESCRIPTION
### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Reduce (unused) code.


### Description
<!-- Describe your changes in detail -->
- Remove unused stuff from `browser_parser`
- Inline remaining two methods from `browser_parser` into `Api`

This removes the property `parser` from `Api` instances. AFAIK this prop is not documented, so I'd consider it private. But if we would consider it public, this PR would be a major change.


### Testing
<!-- Please describe in detail how you tested your changes. -->
I ran `npm t`