### PR TITLE
ci: update github action workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,23 +31,17 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-
-      - name: set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
 
       - name: Environment Information
         run: |
           node --version
           npm --version
-          gradle --version
 
       - name: npm install and test
         run: |
@@ -56,6 +50,6 @@ jobs:
         env:
           CI: true
 
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v3.1.1
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
removed the java step since I don't think is relevant for cordova-browser 
updated the rest