### PR TITLE
chore!: drop node 10 and node 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=14.0.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
In the other platforms we dropped node 10 and 12 support long ago, so I've updated the engine to node >=14 too and added node 18 to the testing matrix.

master branch already includes breaking changes, so next release should be 7.0.0 