### PR TITLE
chore!: set node engine to >=16.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "Apache Software Foundation",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=16.0.0"
   },
   "nyc": {
     "include": [


### PR DESCRIPTION
if we are[ dropping node 14 support](https://github.com/apache/cordova-browser/pull/119) we should update the engines to require node 16
