### PR TITLE
GH-122 browser: permit serving over https

### DIFF
--- a/bin/template/cordova/lib/run.js
+++ b/bin/template/cordova/lib/run.js
@@ -29,6 +29,7 @@ module.exports.run = function (args) {
     args.port = args.port || 8000;
     args.target = args.target || 'default'; // make default the system browser
     args.noLogOutput = args.silent || false;
+    args.https = args.https || false;
 
     const wwwPath = path.join(__dirname, '../../www');
     const manifestFilePath = path.resolve(path.join(wwwPath, 'manifest.json'));
@@ -53,7 +54,7 @@ module.exports.run = function (args) {
                 startPage = 'index.html';
             }
 
-            const projectUrl = (new url.URL(`http://localhost:${server.port}/${startPage}`)).href;
+            const projectUrl = (new url.URL(` ${(args.https) ? 'https' : 'http'}://localhost:${server.port}/${startPage}`)).href;
 
             console.log('startPage = ' + startPage);
             console.log('Static file server running @ ' + projectUrl + '\nCTRL + C to shut down');

--- a/bin/template/cordova/run
+++ b/bin/template/cordova/run
@@ -27,7 +27,7 @@ const args = process.argv;
 start(args);
 
 function start (argv) {
-    const args = nopt({ help: Boolean, target: String, port: Number }, { help: ['/?', '-h', 'help', '-help', '/help'] }, argv);
+    const args = nopt({ help: Boolean, target: String, port: Number, https: Boolean }, { help: ['/?', '-h', 'help', '-help', '/help'] }, argv);
     if (args.help) {
         help();
     } else {
@@ -36,13 +36,15 @@ function start (argv) {
 }
 
 function help () {
-    console.log('\nUsage: run [ --target=<browser> ] [ --port=<number> ]');
+    console.log('\nUsage: run [ --target=<browser> ] [ --port=<number> ] [ --https]');
     console.log('    --target=<browser> : Launches the specified browser. Chrome is default.');
     console.log('    --port=<number>    : Http server uses specified port number.');
+    console.log('    --https            : Http server runs over SSL.');
     console.log('Examples:');
     console.log('    run');
     console.log('    run -- --target=ie');
     console.log('    run -- --target=chrome --port=8000');
+    console.log('    run -- --target=chrome --port=8000 --https');
     console.log('');
     process.exit(0);
 }


### PR DESCRIPTION
<!--
Please make sure the checklist boxes are all checked before submitting the PR. The checklist is intended as a quick reference, for complete details please see our Contributor Guidelines:

http://cordova.apache.org/contribute/contribute_guidelines.html

Thanks!
-->

### Platforms affected
Browser


### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

Closes #122. 


### Description
<!-- Describe your changes in detail -->

This PR adds a new boolean option `--https` which will serve the browser platform over HTTPS.

These issues is other Cordova repos are also required:
* https://github.com/apache/cordova-serve/issues/55
* https://github.com/apache/cordova-cli/issues/621

### Testing
<!-- Please describe in detail how you tested your changes. -->

A test for `cordova run browser` seems not to be present in this repo (?).


### Checklist

- [x] I've run the tests to see all new and existing tests pass
- [ ] I added automated test coverage as appropriate for this change
- [x] Commit is prefixed with `(platform)` if this change only applies to one platform (e.g. `(android)`)
- [x] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x] I've updated the documentation if necessary
